### PR TITLE
fix: load **/**/*.js

### DIFF
--- a/lib/load_schedule.js
+++ b/lib/load_schedule.js
@@ -20,8 +20,11 @@ module.exports = app => {
       continue;
     }
 
-    read(schedulePath, noDotAndJSOnly).forEach(s => {
+    read(schedulePath).forEach(s => {
       s = path.join(schedulePath, s);
+      if (path.extname(s) !== '.js') {
+        return;
+      }
       s = require.resolve(s);
       let schedule = require(s);
 
@@ -41,7 +44,3 @@ module.exports = app => {
   }
   return schedules;
 };
-
-function noDotAndJSOnly(name) {
-  return path.extname(name) === '.js' && name[0] !== '.';
-}


### PR DESCRIPTION
1.1.3 变更后，schedule 子目录下的 js 无法执行
例如：`schedule/message/work.js`，特进行如下修复

```javascript
function noDotAndJSOnly(name) {
  // name 可能是一个文件夹名
  return (path.extname(name) === '' || path.extname(name) === '.js') && name[0] !== '.';
 }
```

本地跑测试，发生如下错误，因此没有提交相应测试代码，望补充

```shell
/Users/BlackGanglion/fullWork/egg-schedule/lib/load_schedule.js:11
  const dirs = app.loader.loadDirs();
                          ^
TypeError: app.loader.loadDirs is not a function
```