### PR TITLE
feat: run a scheduler only once at startup

### DIFF
--- a/lib/timer.js
+++ b/lib/timer.js
@@ -19,8 +19,8 @@ class Timer {
    */
   handler(key, schedule, listener) {
     const { interval, cron, cronOptions, immediate } = schedule;
-    if (!interval && !cron) {
-      throw new Error('[egg-schedule] schedule.interval or schedule.cron must be present');
+    if (!interval && !cron && !immediate) {
+      throw new Error('[egg-schedule] schedule.interval or schedule.cron or schedule.immediate must be present');
     }
 
     if (interval) {

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -3,6 +3,7 @@
 const parser = require('cron-parser');
 const ms = require('humanize-ms');
 const safetimers = require('safe-timers');
+const assert = require('assert');
 
 class Timer {
   constructor(agent) {
@@ -19,9 +20,7 @@ class Timer {
    */
   handler(key, schedule, listener) {
     const { interval, cron, cronOptions, immediate } = schedule;
-    if (!interval && !cron && !immediate) {
-      throw new Error('[egg-schedule] schedule.interval or schedule.cron or schedule.immediate must be present');
-    }
+    assert(interval || cron || immediate, '[egg-schedule] schedule.interval or schedule.cron or schedule.immediate must be present');
 
     if (interval) {
       const tid = this.safeInterval(listener, ms(interval));

--- a/test/fixtures/immediate-onlyonce/app/schedule/immediate-onlyonce.js
+++ b/test/fixtures/immediate-onlyonce/app/schedule/immediate-onlyonce.js
@@ -1,0 +1,10 @@
+'use strict';
+
+exports.schedule = {
+  type: 'worker',
+  immediate: true,
+};
+
+exports.task = async function(ctx) {
+  ctx.logger.info('immediate-onlyonce');
+};

--- a/test/fixtures/immediate-onlyonce/package.json
+++ b/test/fixtures/immediate-onlyonce/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "immediate-onlyonce"
+}

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -85,6 +85,15 @@ describe('test/schedule.test.js', () => {
       assert(contains(log, 'immediate-interval') >= 2);
       assert(contains(log, 'immediate-cron') >= 2);
     });
+
+    it('should support immediate-onlyonce', async () => {
+      app = mm.cluster({ baseDir: 'immediate-onlyonce', workers: 2 });
+      await app.ready();
+      await sleep(1000);
+      const log = getLogContent('immediate-onlyonce');
+      // console.log(log);
+      assert(contains(log, 'immediate-onlyonce') === 1);
+    });
   });
 
   describe('schedule type all', () => {
@@ -157,7 +166,7 @@ describe('test/schedule.test.js', () => {
       app = mm.cluster({ baseDir: 'scheduleError', workers: 2 });
       await app.ready();
       await sleep(1000);
-      assert(/\[egg-schedule\] schedule\.interval or schedule\.cron must be present/.test(getErrorLogContent('scheduleError')));
+      assert(/\[egg-schedule\] schedule\.interval or schedule\.cron or schedule\.immediate must be present/.test(getErrorLogContent('scheduleError')));
     });
   });
 


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
