### PR TITLE
fix: unit-test in 'schedule.test.js'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - '8'
-  - '9'
+  - '10'
 install:
   - npm i npminstall && npminstall
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
     - nodejs_version: '8'
-    - nodejs_version: '9'
+    - nodejs_version: '10'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -46,7 +46,7 @@ class Timer {
   }
 
   /**
-   * clean all timers
+   * clear all the timers
    */
   close() {
     for (const tid of this.interval.values()) {

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -259,8 +259,7 @@ describe('test/schedule.test.js', () => {
     it('should run schedule by absolute package path success', async () => {
       app = mm.app({ baseDir: 'worker', cache: false });
       await app.ready();
-      // console.log(require.resolve('egg/node_modules/egg-logrotator/app/schedule/rotate_by_file.js'));
-      await app.runSchedule(require.resolve('egg/node_modules/egg-logrotator/app/schedule/rotate_by_file.js'));
+      await app.runSchedule(require.resolve('../node_modules/egg-logrotator/app/schedule/rotate_by_file.js'));
     });
   });
 


### PR DESCRIPTION
1) There's an error when having a test with 'should run schedule by
absolute package path success' in 'schedule.test.js'.

2) In travis.yml and appveyor.yml, set nodejs's version to 8,10.

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
