### PR TITLE
doc: Add notice for the evil 'setInterval'

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ exports.schedule = {
   interval: '3h',
 };
 ```
+**Notice: Egg itself WON'T pay attention to an evil problem of `setInterval` (for details, please see:  https://www.thecodeship.com/web-development/alternative-to-javascript-evil-setinterval/ ). So you have to make sure that your actual execution time of your callback set in the `setInterval` must be smaller / equal to your delay time in that function.**
 
 ### Schedule Type
 


### PR DESCRIPTION
Due to https://www.thecodeship.com/web-development/alternative-to-javascript-evil-setinterval/,
we should notify users to make sure that the actual exection time should
be less / equal than that of delay time in setInterval.

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines