### PR TITLE
docs: fix ctx ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ module.exports = app => {
         env: [ 'prod' ],
       };
     }
-    async subscribe(ctx) {
-      await ctx.sync();
+    async subscribe() {
+      await this.ctx.sync();
     }
   }
   return SyncTask;


### PR DESCRIPTION
我在"egg": "^2.15.1"版本中实际使用中这样才能正确运行。