### PR TITLE
add module exports for custom schedule in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ class ClusterTask extends Subscription {
     await this.ctx.service.someTask.run();
   }
 }
+module.exports = ClusterTask;
 ```
 
 ## Dynamic schedule


### PR DESCRIPTION
current document will cause schedule error because scheduler can't find schedule property, so just added module.exports would work.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
