### PR TITLE
feat: support schedule only executes once when it's deployed in k8s clusters mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,22 @@ config.schedule = {
   directory: [
     path.join(__dirname, '../app/otherSchedule'),
   ],
+  // add it when making sure it only running in one cluster. 
+  cluster: {
+    enable: true,
+    // add redis for redis lock
+    redis: {
+      client: {
+        port: 6379, // Redis port
+        host: '127.0.0.1', // Redis host
+        password: 'auth',
+        db: 0,
+      },
+    },
+  },
+  //the prefix for lockedKey for redis lock
+  default: 'default', // default schedule name,like project-name.
+  prefix: 'schedule', // default schedule prefix
 };
 ```
 

--- a/agent.js
+++ b/agent.js
@@ -2,6 +2,7 @@
 
 const WorkerStrategy = require('./lib/strategy/worker');
 const AllStrategy = require('./lib/strategy/all');
+const Redis = require('ioredis');
 
 module.exports = agent => {
   // register built-in strategy
@@ -11,6 +12,12 @@ module.exports = agent => {
   // wait for other plugin to register custom strategy
   agent.beforeStart(() => {
     agent.schedule.init();
+    if (
+      agent.config.schedule?.cluster?.enable &&
+      agent.config.schedule?.cluster?.redis
+    ) {
+      agent.redisClient = new Redis(agent.config.schedule.cluster.redis);
+    }
   });
 
   // dispatch job finish event to strategy

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -13,6 +13,19 @@ module.exports = () => {
   config.schedule = {
     // custom additional directory, full path
     directory: [],
+    cluster: {
+      enable: false,
+      redis: {
+        client: {
+          port: 6379, // Redis port
+          host: '127.0.0.1', // Redis host
+          password: 'auth',
+          db: 0,
+        },
+      },
+    },
+    default: 'default',
+    prefix: 'schedule',
   };
 
   return config;

--- a/lib/strategy/all.js
+++ b/lib/strategy/all.js
@@ -3,7 +3,33 @@
 const Strategy = require('./timer');
 
 module.exports = class AllStrategy extends Strategy {
-  handler() {
-    this.sendAll();
+  async handler() {
+    let isLocked = false;
+    const curConfig = this.agent.config.schedule;
+    let lockedKey = '';
+    if (curConfig?.cluster?.enable) {
+      this.logger.info('cluster mode');
+      const projectName =
+        curConfig.default === 'default'
+          ? this.agent.baseDir.split('/').pop()
+          : curConfig.default;
+      const prefix = curConfig.prefix;
+      lockedKey = `${projectName}-${prefix}-${this.key.replace(
+        this.agent.baseDir,
+        ''
+      )}`;
+      if (await this.agent.redisClient.get(lockedKey)) {
+        isLocked = true;
+      }
+      await this.agent.redisClient.set(lockedKey, true);
+    }
+
+    if (!isLocked) {
+      this.sendAll();
+    }
+
+    if (curConfig.cluster.enable) {
+      await this.agent.redisClient.del(lockedKey);
+    }
   }
 };

--- a/lib/strategy/worker.js
+++ b/lib/strategy/worker.js
@@ -3,7 +3,33 @@
 const Strategy = require('./timer');
 
 module.exports = class WorkerStrategy extends Strategy {
-  handler() {
-    this.sendOne();
+  async handler() {
+    let isLocked = false;
+    const curConfig = this.agent?.config?.schedule;
+    let lockedKey = '';
+    if (curConfig?.cluster?.enable) {
+      this.logger.info('cluster mode');
+      const projectName =
+        curConfig.default === 'default'
+          ? this.agent.baseDir.split('/').pop()
+          : curConfig.default;
+      const prefix = curConfig.prefix;
+      lockedKey = `${projectName}-${prefix}-${this.key.replace(
+        this.agent.baseDir,
+        ''
+      )}`;
+      if (await this.agent.redisClient.get(lockedKey)) {
+        isLocked = true;
+      }
+      await this.agent.redisClient.set(lockedKey, true);
+    }
+
+    if (!isLocked) {
+      this.sendOne();
+    }
+
+    if (curConfig.cluster.enable) {
+      await this.agent.redisClient.del(lockedKey);
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "cron-parser": "^2.16.3",
     "humanize-ms": "^1.2.1",
+    "ioredis": "^5.4.1",
     "is-type-of": "^1.2.1",
     "safe-timers": "^1.1.0",
     "utility": "^1.16.3"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "egg-mock": "^5.3.0",
     "egg-tracer": "^1.1.0",
     "eslint": "^8.29.0",
-    "eslint-config-egg": "^12.1.0"
+    "eslint-config-egg": "^12.1.0",
+    "mocha": "^10.8.2"
   },
   "engines": {
     "node": ">=14.17.0"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes with [github actions](https://github.com/oneWalker/egg-schedule/actions/runs/11803906927)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

support schedule only executes once when it's deployed in k8s clusters mode.
